### PR TITLE
fix(ci): updated triggers for release.

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,9 +1,12 @@
 name: Python Package Release
 
 on:
-  push:
-    tags:
-      - '*'
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
+  release:
+    types:
+      - published
+      - created
+      - released
   workflow_dispatch:
 
 jobs:
@@ -35,6 +38,7 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        # Could be changed with OIDC
         with:
           user: '__token__'
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Issue/PR link
relates: #19 

## What does this PR do?
Describe what changes you make in your branch:
- updated CI triggers from `on.push.tags` from `on.release`

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
This is because the `on.push.tags` will be triggered only `commits` push to main with the tags, whereas release-please-action will only create tags in GitHub side.