### PR TITLE
fix(ci): used PAT instead of GITHUB_TOKEN for release-please-action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,3 +18,4 @@ jobs:
         with:
           manifest-file: .release-please-manifest.json
           config-file: '.github/config/release-please-config.json'
+          token: ${{ secrets.RELEASE_PLEASE_ACTION_PAT }}


### PR DESCRIPTION
## Issue/PR link
relates: #19 

## What does this PR do?
Describe what changes you make in your branch:
SSIA, ref: https://github.com/orgs/community/discussions/25281
The reason why the publishing workflow has not been triggered is, the release-please-action will use GITHUB_TOKEN by default, and this will not trigger other workflow as mentioned in the link above.

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
N/A