### PR TITLE
fix(ci): removed duplications in triggers

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -4,9 +4,7 @@ on:
   # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
   release:
     types:
-      - published
       - created
-      - released
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Issue/PR link
relates: #19 

## What does this PR do?
Describe what changes you make in your branch:
- provided a single trigger events, `on.release.created`, since the publish workflow has been triggered properly by the change of #33, but there were 3 workflow runs with duplications.

![Screenshot 2025-01-29 at 2 49 11](https://github.com/user-attachments/assets/f8fa43b1-912b-4fa8-960a-b6b1bcf53e7d)


## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
N/A