### PR TITLE
fix: added repository options to checkout in being triggered.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        repository: hwakabh/envkeeper
 
     - name: Setup Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
## Issue/PR link
relates: #58 

## What does this PR do?
Describe what changes you make in your branch:
- added `repository` fields to action.yml, where the steps defined of this GitHub Actions

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- instead of replacing `with.python-version-file` to `with.python-version` in [`actions/setup-python`](https://github.com/actions/setup-python), we can explicitly provide checkout repository when this Github Actions will be invoked