### PR TITLE
fix: typo in status_code returned from delete_inactive_deployment().

### DIFF
--- a/envkp/core.py
+++ b/envkp/core.py
@@ -104,7 +104,7 @@ def cli():
                         gh_reponame=GH_REPONAME,
                         reqheader=HEADER
                     )
-                    if status_code() != 204:
+                    if status_code != 204:
                         print('Error')
                     else:
                         print(f'Done, {status_code}')


### PR DESCRIPTION
## Issue/PR link
relates: #38 (PR: #63 , #64 )
fixed:

```shell
% docker run -e GH_TOKEN='***' ghcr.io/hwakabh/envkp:latest version
0.6.1

% docker run -e GH_TOKEN='***' ghcr.io/hwakabh/envkp:latest --repo=hwakabh/envkeeper clean
Fetching GitHub username & repository name from shell
Fetching GitHub PAT from shell
>>> Starting operations: clean
Get mappings between environments and deployments from repo: hwakabh/envkeeper
Got 13

Get list of environments ...
pypi

Get deployments related to each environment ...
Environment [ pypi ] has the following deployments: 
>>> Found 2 statues in deployment_id [ 2255524128 ]
2255524128: Inactive False
2255524128: Deployment is active, nothing to do ...
>>> Found 3 statues in deployment_id [ 2255505822 ]
2255505822: Inactive True
2255505822: Delete the deployment ...
Traceback (most recent call last):
  File "/layers/paketo-buildpacks_pip-install/packages/bin/envkp", line 8, in <module>
    sys.exit(cli())
             ~~~^^
  File "/layers/paketo-buildpacks_pip-install/packages/lib/python3.13/site-packages/envkp/core.py", line 107, in cli
    if status_code() != 204:
       ~~~~~~~~~~~^^
TypeError: 'int' object is not callable
```

## What does this PR do?
Describe what changes you make in your branch:
SSIA

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
N/A